### PR TITLE
Support GEOS 3.4.x

### DIFF
--- a/coanacatl/coanacatl.cpp
+++ b/coanacatl/coanacatl.cpp
@@ -30,7 +30,14 @@ const uint64_t FID_NONE = std::numeric_limits<uint64_t>::max();
 #define INIT_GEOS GEOS_init_r()
 #define FINISH_GEOS GEOS_finish_r
 #else
-#define INIT_GEOS initGEOS_r(printf, printf)
+#include <stdarg.h>
+void _coanacatl_printf(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vprintf(fmt, ap);
+  va_end(ap);
+}
+#define INIT_GEOS initGEOS_r(_coanacatl_printf, _coanacatl_printf)
 #define FINISH_GEOS finishGEOS_r
 #endif
 

--- a/coanacatl/coanacatl.cpp
+++ b/coanacatl/coanacatl.cpp
@@ -26,11 +26,19 @@ typedef mgw::wagyu<coord> wagyu;
 // IDs to None and keep the real ID in the properties.
 const uint64_t FID_NONE = std::numeric_limits<uint64_t>::max();
 
+#if GEOS_CAPI_VERSION_MINOR >= 9
+#define INIT_GEOS GEOS_init_r()
+#define FINISH_GEOS GEOS_finish_r
+#else
+#define INIT_GEOS initGEOS_r(printf, printf)
+#define FINISH_GEOS finishGEOS_r
+#endif
+
 class encoder {
 public:
   encoder(bp::tuple bounds, size_t extents)
     : m_extents(extents)
-    , m_geos_ctx(GEOS_init_r()) {
+    , m_geos_ctx(INIT_GEOS) {
     if (bp::len(bounds) != 4) {
       throw std::runtime_error("Bounds tuple must have 4 elements.");
     }
@@ -41,7 +49,7 @@ public:
   }
 
   ~encoder() {
-    GEOS_finish_r(m_geos_ctx);
+    FINISH_GEOS(m_geos_ctx);
   }
 
   void encode_layer(bp::object layer);


### PR DESCRIPTION
Coanacatl was originally written against GEOS version 3.5.x, which has slightly different initialisation and finalisation functions from the previous version, 3.4.x. Although 3.5.x is the current version on Ubuntu 16.04, 3.4.x is the installation candidate on other distributions (e.g: in the `python:2` Docker image - although it is based on Debian stretch, which seems to have 3.5.1 :confused:).

:man_shrugging:, it's good to be able to handle both versions if they're "out there" in the wild.
