### PR TITLE
Fix typos leading to bad coordinates in tiles

### DIFF
--- a/coanacatl/coanacatl.cpp
+++ b/coanacatl/coanacatl.cpp
@@ -214,7 +214,7 @@ void encoder::encode_point(
 
   double x, y;
   GEOSGeomGetX_r(m_geos_ctx, geometry, &x);
-  GEOSGeomGetX_r(m_geos_ctx, geometry, &y);
+  GEOSGeomGetY_r(m_geos_ctx, geometry, &y);
   vtzero::point p = translate(x, y);
   fb.add_point(p);
 
@@ -343,7 +343,7 @@ void encoder::encode_multi_point(
     }
     double x, y;
     GEOSGeomGetX_r(m_geos_ctx, geom, &x);
-    GEOSGeomGetX_r(m_geos_ctx, geom, &y);
+    GEOSGeomGetY_r(m_geos_ctx, geom, &y);
     vtzero::point p = translate(x, y);
     fb.set_point(p);
   }

--- a/coanacatl/coanacatl.cpp
+++ b/coanacatl/coanacatl.cpp
@@ -199,7 +199,7 @@ void encoder::add_properties(vtzero::feature_builder &fb, bp::dict props) {
 
 vtzero::point encoder::translate(double x, double y) {
   int quant_x = double(m_extents) * (x - m_minx) / (m_maxx - m_minx);
-  int quant_y = double(m_extents) * (y - m_miny) / (m_maxy - m_miny);
+  int quant_y = double(m_extents) * (m_maxy - y) / (m_maxy - m_miny);
   return vtzero::point(quant_x, quant_y);
 }
 


### PR DESCRIPTION
D'oh :man_facepalming: 

This fixes a couple of problems:

1. The transform of the `y` coordinate from mercator coordinates to MVT tile coordinates was the same as the `x` coordinate, but MVT tile coordinates are "screen space" - so `y` increases down, not up.
2. A couple of places that copy-and-paste was used, and the method name for the `x` coordinate wasn't changed to fetch the `y` coordinate, meaning those points got the same value for both axes.
