### PR TITLE
Fix unicode handling for property keys, layer names.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Checkout submodules
+          command: git submodule update --init --recursive
+      - run:
           name: Install C++ dependencies
           command: sudo apt install build-essential libgeos-dev libboost-python-dev
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:2.7.15-stretch
+    steps:
+      - checkout
+      - run:
+          name: Install C++ dependencies
+          command: sudo apt install build-essential libgeos-dev libboost-python-dev
+      - run:
+          name: Install Python dependencies
+          command: sudo pip install shapely
+      - run:
+          name: Build library
+          command: python setup.py build
+      - run:
+          name: Unit tests
+          command: python setup.py test

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Where:
 You will need to install a C++11 build system and the GEOS library, e.g: if you are on Ubuntu or Debian:
 
 ```
-sudo apt install build-essential libgeos-dev
+sudo apt install build-essential libgeos-dev libboost-python-dev
+```
+
+You will also need the [Shapely](http://toblerity.org/shapely/) Python library. Install (with or without `sudo` depending on whether you're installing it globally or locally):
+
+```
+pip install shapely
 ```
 
 **NOTE: probably other stuff as well! Please [file an issue](https://github.com/tilezen/coanacatl/issues/new) if you find you need additional dependencies.**
@@ -41,8 +47,8 @@ python setup.py install
 ## Current limitations
 
 * Only point, linestring, polygon and multi-versions of those are supported. Linear rings and geometry collections are currently not supported.
-* Property dictionary keys must be strings, as per the MVT spec. Property dictionary values can be boolean, integer, floating point or strings.
-* There are **no tests**!
+* Property dictionary keys must be strings (or `unicode`), as per the MVT spec. Property dictionary values can be boolean, integer, floating point or strings.
+* There are **very few tests**!
 * Error checking of return values from the GEOS API is inadequate, and needs shoring up.
 * There needs to be a better way to return warnings/errors to the user, perhaps as a list of objects, so that the user can determine if it's enough to fail the tile or just log.
 

--- a/test.py
+++ b/test.py
@@ -24,6 +24,103 @@ class GeometryTest(TestCase):
         features = [
             dict(
                 geometry=Point(0, 0),
+                properties={},
+                id=1
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_linestring(self):
+        from shapely.geometry import LineString
+
+        features = [
+            dict(
+                geometry=LineString([(0, 0), (1, 1)]),
+                properties={},
+                id=None
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_polygon(self):
+        from shapely.geometry import Point
+
+        features = [
+            dict(
+                geometry=Point(0, 0).buffer(1),
+                properties={},
+                id=3
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_multipoint(self):
+        from shapely.geometry import MultiPoint
+
+        features = [
+            dict(
+                geometry=MultiPoint([(0, 0), (1, 1)]),
+                properties={},
+                id=None
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_multilinestring(self):
+        from shapely.geometry import MultiLineString
+
+        features = [
+            dict(
+                geometry=MultiLineString([[(0, 0), (1, 0)], [(0, 1), (1, 1)]]),
+                properties={},
+                id=None
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_multipolygon(self):
+        from shapely.geometry import Point
+
+        features = [
+            dict(
+                geometry=Point(0, 0).buffer(0.4).union(
+                    Point(1, 1).buffer(0.4)),
+                properties={},
+                id=4
+            ),
+        ]
+
+        self._generate_tile(features)
+
+
+class PropertyTest(TestCase):
+
+    def _generate_tile(self, features):
+        import coanacatl
+
+        layers = [dict(
+            name='layer',
+            features=features,
+        )]
+
+        bounds = (0, 0, 1, 1)
+        extents = 4096
+
+        tile_data = coanacatl.encode(layers, bounds, extents)
+        self.assertTrue(tile_data)
+        return tile_data
+
+    def test_property_types(self):
+        from shapely.geometry import Point
+
+        features = [
+            dict(
+                geometry=Point(0, 0),
                 properties={
                     'string': 'string_value',
                     'long': 4294967297L,
@@ -37,67 +134,56 @@ class GeometryTest(TestCase):
 
         self._generate_tile(features)
 
-    def test_linestring(self):
-        from shapely.geometry import LineString
-
-        features = [
-            dict(
-                geometry=LineString([(0, 0), (1, 1)]),
-                properties={'baz': 'bat'},
-                id=None
-            ),
-        ]
-
-        self._generate_tile(features)
-
-    def test_polygon(self):
+    def test_unicode_property_value(self):
         from shapely.geometry import Point
 
         features = [
             dict(
-                geometry=Point(0, 0).buffer(1),
-                properties={'blah': 'blah', 'id': 123},
-                id=3
+                geometry=Point(0, 0),
+                properties={
+                    'string': unicode('unicode_value'),
+                },
+                id=1
             ),
         ]
 
         self._generate_tile(features)
 
-    def test_multipoint(self):
-        from shapely.geometry import MultiPoint
-
-        features = [
-            dict(
-                geometry=MultiPoint([(0, 0), (1, 1)]),
-                properties={'foo': 'bar', 'boolean': False},
-                id=None
-            ),
-        ]
-
-        self._generate_tile(features)
-
-    def test_multilinestring(self):
-        from shapely.geometry import MultiLineString
-
-        features = [
-            dict(
-                geometry=MultiLineString([[(0, 0), (1, 0)], [(0, 1), (1, 1)]]),
-                properties={'foo': 'bar'},
-                id=None
-            ),
-        ]
-
-        self._generate_tile(features)
-
-    def test_multipolygon(self):
+    def test_unicode_property_key(self):
         from shapely.geometry import Point
 
         features = [
             dict(
-                geometry=Point(0, 0).buffer(0.4).union(Point(1, 1).buffer(0.4)),
-                properties={'blah': 'blah'},
-                id=4
+                geometry=Point(0, 0),
+                properties={
+                    unicode('unicode'): 'string_value',
+                },
+                id=1
             ),
         ]
 
         self._generate_tile(features)
+
+    def test_unicode_layer_name(self):
+        import coanacatl
+        from shapely.geometry import Point
+
+        layers = [dict(
+            name=unicode('layer'),
+            features=[
+                dict(
+                    geometry=Point(0, 0),
+                    properties={
+                        'foo': 'bar',
+                    },
+                    id=1
+                ),
+            ],
+        )]
+
+        bounds = (0, 0, 1, 1)
+        extents = 4096
+
+        tile_data = coanacatl.encode(layers, bounds, extents)
+        self.assertTrue(tile_data)
+        return tile_data

--- a/test.py
+++ b/test.py
@@ -1,60 +1,103 @@
-import coanacatl
-from shapely.geometry import Point
-from shapely.geometry import LineString
-from shapely.geometry import Polygon
-from shapely.geometry import MultiPoint
-from shapely.geometry import MultiLineString
-from shapely.geometry import MultiPolygon
+from unittest import TestCase
 
 
-features = [
-    dict(
-        geometry=Point(0, 0),
-        properties={
-            'string': 'string_value',
-            'long': 4294967297L,
-            'int': 1,
-            'float': 1.0,
-            'bool': True,
-        },
-        id=1
-    ),
-    dict(
-        geometry=LineString([(0, 0), (1, 1)]),
-        properties={'baz': 'bat'},
-        id=None
-    ),
-    dict(
-        geometry=Point(0, 0).buffer(1),
-        properties={'blah': 'blah', 'id': 123},
-        id=3
-    ),
-    dict(
-        geometry=MultiPoint([(0, 0), (1, 1)]),
-        properties={'foo': 'bar', 'boolean': False},
-        id=None
-    ),
-    dict(
-        geometry=MultiLineString([[(0, 0), (1, 0)], [(0, 1), (1, 1)]]),
-        properties={'foo': 'bar'},
-        id=None
-    ),
-    dict(
-        geometry=Point(0, 0).buffer(0.4).union(Point(1, 1).buffer(0.4)),
-        properties={'blah': 'blah'},
-        id=4
-    ),
-]
+class GeometryTest(TestCase):
 
-layers = [dict(
-    name='layer',
-    features=features,
-)]
+    def _generate_tile(self, features):
+        import coanacatl
 
-bounds = (0, 0, 1, 1)
-extents = 4096
+        layers = [dict(
+            name='layer',
+            features=features,
+        )]
 
-tile_data = coanacatl.encode(layers, bounds, extents)
-print repr(tile_data)
-with open('foo.mvt', 'w') as fh:
-    fh.write(tile_data)
+        bounds = (0, 0, 1, 1)
+        extents = 4096
+
+        tile_data = coanacatl.encode(layers, bounds, extents)
+        self.assertTrue(tile_data)
+        return tile_data
+
+    def test_point(self):
+        from shapely.geometry import Point
+
+        features = [
+            dict(
+                geometry=Point(0, 0),
+                properties={
+                    'string': 'string_value',
+                    'long': 4294967297L,
+                    'int': 1,
+                    'float': 1.0,
+                    'bool': True,
+                },
+                id=1
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_linestring(self):
+        from shapely.geometry import LineString
+
+        features = [
+            dict(
+                geometry=LineString([(0, 0), (1, 1)]),
+                properties={'baz': 'bat'},
+                id=None
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_polygon(self):
+        from shapely.geometry import Point
+
+        features = [
+            dict(
+                geometry=Point(0, 0).buffer(1),
+                properties={'blah': 'blah', 'id': 123},
+                id=3
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_multipoint(self):
+        from shapely.geometry import MultiPoint
+
+        features = [
+            dict(
+                geometry=MultiPoint([(0, 0), (1, 1)]),
+                properties={'foo': 'bar', 'boolean': False},
+                id=None
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_multilinestring(self):
+        from shapely.geometry import MultiLineString
+
+        features = [
+            dict(
+                geometry=MultiLineString([[(0, 0), (1, 0)], [(0, 1), (1, 1)]]),
+                properties={'foo': 'bar'},
+                id=None
+            ),
+        ]
+
+        self._generate_tile(features)
+
+    def test_multipolygon(self):
+        from shapely.geometry import Point
+
+        features = [
+            dict(
+                geometry=Point(0, 0).buffer(0.4).union(Point(1, 1).buffer(0.4)),
+                properties={'blah': 'blah'},
+                id=4
+            ),
+        ]
+
+        self._generate_tile(features)


### PR DESCRIPTION
I'm pretty sure we shouldn't have `unicode` values for property keys or layer names, but looks like some slipped in somewhere and we're getting errors. This patch just makes sure that anywhere we're expecting a string we can also handle `unicode` by converting to UTF-8.

Also changes the test suite to be based on `unittest`, although it still only checks that the output is generated without error and the resulting tile is truthy. See #3 for future work on making the tests do more useful stuff, such as checking the content of the tiles.

Also adds a CircleCI config.
