### PR TITLE
Do not output empty geometries

### DIFF
--- a/coanacatl/coanacatl.cpp
+++ b/coanacatl/coanacatl.cpp
@@ -438,15 +438,13 @@ void encoder::encode_wagyu_result(
     mgw::fill_type_even_odd,
     mgw::fill_type_even_odd);
 
-  if (!ok) {
+  if (!ok || result.empty()) {
     // this is probably because the polygon ended up being degenerate in integer
     // coordinates.
 
     // TODO: warning?
     return;
   }
-
-  assert(result.size() > 0);
 
   vtzero::polygon_feature_builder fb{lb};
   add_id(fb, fid);

--- a/coanacatl/coanacatl.cpp
+++ b/coanacatl/coanacatl.cpp
@@ -142,7 +142,7 @@ private:
     vtzero::layer_builder &lb);
   polygon geom_to_poly(const GEOSGeom_t *geometry);
   linear_ring ring_to_mbg(const GEOSGeom_t *linear_ring);
-  void add_linestring(vtzero::linestring_feature_builder &fb, const GEOSGeom_t *geometry);
+  std::vector<vtzero::point> distinct_linestring(const GEOSGeom_t *geometry);
   void encode_wagyu_result(
     wagyu &w,
     bp::dict props,
@@ -248,10 +248,8 @@ void encoder::encode_point(
   add_properties(fb, props);
 }
 
-void encoder::add_linestring(
-  vtzero::linestring_feature_builder &fb,
+std::vector<vtzero::point> encoder::distinct_linestring(
   const GEOSGeom_t *geometry) {
-
   // NOTE: coord_seq is owned by the geometry, so we do not free it.
   const GEOSCoordSequence *coord_seq = GEOSGeom_getCoordSeq_r(m_geos_ctx, geometry);
   if (coord_seq == nullptr) {
@@ -266,14 +264,22 @@ void encoder::add_linestring(
     throw std::runtime_error("Must have at least 2 points in a linestring");
   }
 
+  // only use _distinct_ points. it's not allowed to have two adjacent
+  // points with the same coordinates.
+  std::vector<vtzero::point> distinct;
+  distinct.reserve(num_points);
+
   double x, y;
-  fb.add_linestring(num_points);
   for (unsigned int i = 0; i < num_points; ++i) {
     GEOSCoordSeq_getX_r(m_geos_ctx, coord_seq, i, &x);
     GEOSCoordSeq_getY_r(m_geos_ctx, coord_seq, i, &y);
     vtzero::point p = translate(x, y);
-    fb.set_point(p);
+    if (i == 0 || p != distinct[i-1]) {
+      distinct.push_back(p);
+    }
   }
+
+  return distinct;
 }
 
 void encoder::encode_linestring(
@@ -282,12 +288,18 @@ void encoder::encode_linestring(
   uint64_t fid,
   vtzero::layer_builder &lb) {
 
-  vtzero::linestring_feature_builder fb{lb};
-  add_id(fb, fid);
+  auto distinct = distinct_linestring(geometry);
 
-  add_linestring(fb, geometry);
+  // ignore a geometry with not enough distinct points.
+  // TODO: we should log this!
+  if (distinct.size() >= 2) {
+    vtzero::linestring_feature_builder fb{lb};
+    add_id(fb, fid);
 
-  add_properties(fb, props);
+    fb.add_linestring_from_container(distinct);
+
+    add_properties(fb, props);
+  }
 }
 
 linear_ring encoder::ring_to_mbg(const GEOSGeom_t *geos_ring) {
@@ -384,8 +396,8 @@ void encoder::encode_multi_linestring(
   uint64_t fid,
   vtzero::layer_builder &lb) {
 
+  bool output_started = false;
   vtzero::linestring_feature_builder fb{lb};
-  add_id(fb, fid);
 
   const int num_geoms = GEOSGetNumGeometries_r(m_geos_ctx, multi_geometry);
   if (num_geoms < 0) {
@@ -397,10 +409,24 @@ void encoder::encode_multi_linestring(
     if (geom == nullptr) {
       throw std::runtime_error("Error calling GEOSGetGeometryN_r");
     }
-    add_linestring(fb, geom);
+    auto distinct = distinct_linestring(geom);
+    // ignore degenerate linestrings without at least 2 distinct points.
+    // TODO: log warnings.
+    if (distinct.size() >= 2) {
+      // lazy output of ID, in case we don't actually end up outputting anything
+      // at all, then we can just ignore the whole feature.
+      if (!output_started) {
+        add_id(fb, fid);
+        output_started = true;
+      }
+
+      fb.add_linestring_from_container(distinct);
+    }
   }
 
-  add_properties(fb, props);
+  if (output_started) {
+    add_properties(fb, props);
+  }
 }
 
 void encoder::encode_multi_polygon(

--- a/test.py
+++ b/test.py
@@ -187,3 +187,40 @@ class PropertyTest(TestCase):
         tile_data = coanacatl.encode(layers, bounds, extents)
         self.assertTrue(tile_data)
         return tile_data
+
+
+class DiscardEmptyTest(TestCase):
+
+    def test_discard_empty_polygon(self):
+        """
+        Test that a polygon which becomes invalid (no rings returned from
+        Wagyu) is discarded, rather than being output as an empty geometry.
+        """
+
+        import coanacatl
+        from shapely.wkb import loads as wkb_loads
+
+        shape = wkb_loads(
+            '0103000000010000000400000000000000DAA90C4100000050AECA5741001F3A'
+            '68F4A90C41647D6020AFCA5741001F3A68F4A90C4195DC9C73AECA5741000000'
+            '00DAA90C4100000050AECA5741'.decode('hex'))
+
+        layers = [dict(
+            name=unicode('layer'),
+            features=[
+                dict(
+                    geometry=shape,
+                    properties={
+                        'foo': 'bar',
+                    },
+                    id=1
+                ),
+            ],
+        )]
+
+        bounds = (156543.03392808512, 6183449.840157587,
+                  234814.5508921072, 6261721.357121607)
+        extents = 8192
+
+        tile_data = coanacatl.encode(layers, bounds, extents)
+        self.assertEqual('', tile_data)

--- a/test.py
+++ b/test.py
@@ -224,3 +224,28 @@ class DiscardEmptyTest(TestCase):
 
         tile_data = coanacatl.encode(layers, bounds, extents)
         self.assertEqual('', tile_data)
+
+    def test_discard_empty_line(self):
+        import coanacatl
+        from shapely.geometry import LineString
+
+        shape = LineString([(0, 0), (1.0e-10, 0)])
+
+        layers = [dict(
+            name=unicode('layer'),
+            features=[
+                dict(
+                    geometry=shape,
+                    properties={
+                        'foo': 'bar',
+                    },
+                    id=1
+                ),
+            ],
+        )]
+
+        bounds = (0, 0, 1, 1)
+        extents = 4096
+
+        tile_data = coanacatl.encode(layers, bounds, extents)
+        self.assertEqual('', tile_data)


### PR DESCRIPTION
Some tiles generated by coanacatl were [causing problems](https://github.com/tilezen/vector-datasource/issues/1594) because the geometry for a feature was empty. In addition to wasting space in the tile, this is [not allowed in MVT](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#42-features).

The problem seemed to be that a polygon was so small that it was becoming degenerate, and Wagyu was returning an empty result. For reasons that I still don't understand, the `assert(result.size() > 0)` was being ignored and not causing a crash, so the feature was being output with an empty geometry.

Fixed so that the feature gets skipped rather than output without geometry. At some future point we should thread a logger through the code so that we can capture these as warnings.

Also gave a similar treatment for linestrings and multilinestrings, so that if they consist entirely of repeated points (also not allowed in MVT) then they are dropped (silently for the moment).

Connects to https://github.com/tilezen/vector-datasource/issues/1594.